### PR TITLE
Remove licencse classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Evidently these were superseded and installation fails.

https://peps.python.org/pep-0639/

<details>
  <summary>Things go boom</summary>
  
```
> pip install -e .
Obtaining file:///Users/sdoran/Developer/beef
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error

  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [47 lines of output]
      No `packages` or `py_modules` configuration, performing automatic discovery.
      `flat-layout` detected -- analysing .
      discovered packages -- []
      discovered py_modules -- ['beef']
      Traceback (most recent call last):
        File "/Users/sdoran/.pyenv/versions/3.13.3/envs/beef/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
          ~~~~^^
        File "/Users/sdoran/.pyenv/versions/3.13.3/envs/beef/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ~~~~^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/sdoran/.pyenv/versions/3.13.3/envs/beef/lib/python3.13/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 157, in get_requires_for_build_editable
          return hook(config_settings)
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 473, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
          ~~~~~~~~~~~~~~^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
          ~~~~^^^^^^^^^^^^^^^^
        File "<string>", line 1, in <module>
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/_distutils/core.py", line 160, in setup
          dist.parse_config_files()
          ~~~~~~~~~~~~~~~~~~~~~~~^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/dist.py", line 758, in parse_config_files
          pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/config/pyprojecttoml.py", line 73, in apply_configuration
          return _apply(dist, config, filepath)
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py", line 61, in apply
          dist._finalize_license_expression()
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
        File "/private/tmp/pip-build-env-9jzq9_8_/overlay/lib/python3.13/site-packages/setuptools/dist.py", line 432, in _finalize_license_expression
          raise InvalidConfigError(
          ...<3 lines>...
          )
      setuptools.errors.InvalidConfigError: License classifiers have been superseded by license expressions (see https://peps.python.org/pep-0639/). Please remove:

      License :: OSI Approved :: MIT License
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
</details>